### PR TITLE
Remove Category and Tag types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ libraryDependencies ++= Seq(
  "org.tpolecat" %% "doobie-core-cats" % "0.4.1",
  "org.tpolecat" %% "doobie-h2-cats" % "0.4.1",
  "org.tpolecat" %% "doobie-scalatest-cats" % "0.4.1",
- "com.h2database"            %  "h2"                             % "1.4.195"
+ "com.h2database"            %  "h2"                             % "1.4.195",
+ "joda-time" % "joda-time" % "2.9.9"
 )
 
 enablePlugins(ScalafmtPlugin)

--- a/functional_test/live_tests/conftest.py
+++ b/functional_test/live_tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+from pet_store_client import PetStoreClient
+
+@pytest.fixture(scope="session")
+def pet_store_client(request):
+    return PetStoreClient()
+
+
+@pytest.fixture(scope="session")
+def pet_context(request, pet_store_client):
+    pet = {
+        "name": "Harry",
+        "category": "Cat",
+        "bio": "I am fuzzy",
+        "status": "Available",
+        "tags": [],
+        "photoUrls": []
+    }
+
+    saved_pet = pet_store_client.create_pet(pet).json()
+
+    def fin():
+        pet_store_client.delete_pet(saved_pet['id'])
+
+    request.addfinalizer(fin)
+
+    return saved_pet

--- a/functional_test/live_tests/orders_test.py
+++ b/functional_test/live_tests/orders_test.py
@@ -1,0 +1,18 @@
+import pytest
+from hamcrest import *
+from pet_store_client import PetStoreClient
+
+
+def test_place_order(pet_context, pet_store_client):
+    order = {
+        "petId": pet_context['id'],
+        "status": "Placed",
+        "complete": False
+    }
+    response = pet_store_client.place_order(order)
+
+    order = response.json()
+    assert_that(order['status'], is_('Placed'))
+    assert_that(order['complete'], is_(False))
+    assert_that(order['id'], is_(not_none()))
+    assert_that(order['shipDate'], is_(none()))

--- a/functional_test/live_tests/pets_test.py
+++ b/functional_test/live_tests/pets_test.py
@@ -2,33 +2,6 @@ import pytest
 from hamcrest import *
 from pet_store_client import PetStoreClient
 
-
-@pytest.fixture(scope="session")
-def pet_store_client(request):
-    return PetStoreClient()
-
-
-@pytest.fixture(scope="session")
-def pet_context(request, pet_store_client):
-    pet = {
-        "name": "Harry",
-        "category": "Cat",
-        "bio": "I am fuzzy",
-        "status": "Available",
-        "tags": [],
-        "photoUrls": []
-    }
-
-    saved_pet = pet_store_client.create_pet(pet).json()
-
-    def fin():
-        pet_store_client.delete_pet(saved_pet['id'])
-
-    request.addfinalizer(fin)
-
-    return saved_pet
-
-
 def test_get_pet(pet_context, pet_store_client):
     response = pet_store_client.get_pet(pet_context['id'])
 

--- a/functional_test/pet_store_client.py
+++ b/functional_test/pet_store_client.py
@@ -61,4 +61,13 @@ class PetStoreClient(object):
 
         return self.session.request('DELETE', url, self.headers)
 
+    def place_order(self, order):
+        """
+        Places an order for a pet
+        """
+        url = urljoin(self.index_url, '/orders')
+
+        return self.session.request('POST', url, self.headers, json.dumps(order))
+
+
 

--- a/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
@@ -2,10 +2,10 @@ package io.github.pauljamescleary.petstore
 
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.util.StreamApp
-import io.github.pauljamescleary.petstore.repository.{DoobiePetRepositoryInterpreter, PetRepositoryInMemoryInterpreter}
+import io.github.pauljamescleary.petstore.repository.{DoobieOrderRepositoryInterpreter, DoobiePetRepositoryInterpreter, PetRepositoryInMemoryInterpreter}
 import io.github.pauljamescleary.petstore.validation.PetValidationTaskInterpreter
-import io.github.pauljamescleary.petstore.service.PetService
-import io.github.pauljamescleary.petstore.endpoint.PetEndpoints
+import io.github.pauljamescleary.petstore.service.{OrderService, PetService}
+import io.github.pauljamescleary.petstore.endpoint.{OrderEndpoints, PetEndpoints}
 import fs2._
 
 object Server extends StreamApp {
@@ -13,11 +13,14 @@ object Server extends StreamApp {
   private implicit val petRepo = DoobiePetRepositoryInterpreter()
   private implicit val petValidation = new PetValidationTaskInterpreter
   private implicit val petService = new PetService[Task]
+  private implicit val orderRepo = DoobieOrderRepositoryInterpreter()
+  private implicit val orderService = new OrderService[Task]
 
   override def stream(args: List[String]): Stream[Task, Nothing] = {
     BlazeBuilder
       .bindHttp(8080, "localhost")
       .mountService(PetEndpoints.endpoints(petService), "/")
+      .mountService(OrderEndpoints.endpoints(orderService), "/")
       .serve
   }
 }

--- a/src/main/scala/io/github/pauljamescleary/petstore/endpoint/JodaDateTime.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/endpoint/JodaDateTime.scala
@@ -1,0 +1,21 @@
+package io.github.pauljamescleary.petstore.endpoint
+
+import io.circe.{Decoder, Encoder, Json}
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+
+object JodaDateTime {
+  private val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+  implicit val decodeDateTime: Decoder[DateTime] = Decoder.instance { cursor =>
+    cursor.as[String].flatMap {
+      dateTime => Right(this.fromString(dateTime))
+    }
+  }
+
+  implicit val encodeDateTime: Encoder[DateTime] = Encoder.instance {
+    dateTime: DateTime => Json.fromString(this.toString(dateTime))
+  }
+
+  def toString(dateTime: DateTime): String = dateTime.toString(dateFormat)
+  def fromString(dateTime: String): DateTime = DateTime.parse(dateTime, DateTimeFormat.forPattern(dateFormat))
+}

--- a/src/main/scala/io/github/pauljamescleary/petstore/endpoint/OrderEndpoints.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/endpoint/OrderEndpoints.scala
@@ -1,0 +1,40 @@
+package io.github.pauljamescleary.petstore.endpoint
+
+import fs2.Task
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.auto._
+import io.circe.generic.extras.semiauto._
+import io.github.pauljamescleary.petstore.model.{Order, OrderStatus}
+import io.github.pauljamescleary.petstore.service.OrderService
+import org.http4s.HttpService
+import org.http4s.circe._
+import org.http4s.dsl._
+
+import scala.language.higherKinds
+
+object OrderEndpoints {
+
+  /* Need Joda DateTime Json Encoding */
+  import JodaDateTime._
+
+  /* Needed for service composition via |+| */
+  import cats.implicits._
+
+  /* We need to define an enum encoder and decoder since these do not come out of the box with generic derivation */
+  implicit val statusDecoder = deriveEnumerationDecoder[OrderStatus]
+  implicit val statusEncoder = deriveEnumerationEncoder[OrderStatus]
+
+  def placeOrderEndpoint(orderService: OrderService[Task]): HttpService = HttpService {
+    case req@POST -> Root / "orders" => {
+      for {
+        order <- req.as(jsonOf[Order])
+        saved <- orderService.placeOrder(order)
+        resp <- Ok(saved.asJson)
+      } yield resp
+    }
+  }
+
+  def endpoints(orderService: OrderService[Task]): HttpService =
+    placeOrderEndpoint(orderService)
+}

--- a/src/main/scala/io/github/pauljamescleary/petstore/model/Category.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/model/Category.scala
@@ -1,3 +1,0 @@
-package io.github.pauljamescleary.petstore.model
-
-case class Category(name: String, id: Option[Long])

--- a/src/main/scala/io/github/pauljamescleary/petstore/model/Order.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/model/Order.scala
@@ -1,0 +1,11 @@
+package io.github.pauljamescleary.petstore.model
+
+import org.joda.time.DateTime
+
+case class Order(
+  petId: Long,
+  shipDate: Option[DateTime] = None,
+  status: OrderStatus = Placed,
+  complete: Boolean = false,
+  id: Option[Long] = None
+)

--- a/src/main/scala/io/github/pauljamescleary/petstore/model/OrderStatus.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/model/OrderStatus.scala
@@ -1,0 +1,20 @@
+package io.github.pauljamescleary.petstore.model
+
+sealed trait OrderStatus
+case object Approved extends OrderStatus
+case object Delivered extends OrderStatus
+case object Placed extends OrderStatus
+
+object OrderStatus {
+  def apply(name: String): OrderStatus = name match {
+    case "Approved" => Approved
+    case "Delivered" => Delivered
+    case "Placed" => Placed
+  }
+
+  def nameOf(status: OrderStatus): String = status match {
+    case Approved => "Approved"
+    case Delivered => "Delivered"
+    case Placed => "Placed"
+  }
+}

--- a/src/main/scala/io/github/pauljamescleary/petstore/model/Tag.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/model/Tag.scala
@@ -1,3 +1,0 @@
-package io.github.pauljamescleary.petstore.model
-
-case class Tag(name: String, id: Option[Long])

--- a/src/main/scala/io/github/pauljamescleary/petstore/repository/DoobieOrderRepositoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/repository/DoobieOrderRepositoryInterpreter.scala
@@ -1,0 +1,72 @@
+package io.github.pauljamescleary.petstore.repository
+
+import doobie.imports._
+import cats._
+import cats.data._
+import cats.implicits._
+import fs2.interop.cats._
+import shapeless._
+import shapeless.record.Record
+import fs2.Task
+import io.github.pauljamescleary.petstore.model.{Order, OrderStatus}
+import org.joda.time.DateTime
+
+class DoobieOrderRepositoryInterpreter(val xa: Transactor[Task]) extends OrderRepositoryAlgebra[Task] {
+
+  // This will clear the database on start.  Note, this would typically be done via something like FLYWAY (TODO)
+  sql"""
+    DROP TABLE IF EXISTS ORDERS
+  """.update.run.transact(xa).unsafeRun
+
+  // The tags column is controversial, could be a lookup table.  For our purposes, indexing on tags to allow searching is fine
+  sql"""
+    CREATE TABLE ORDERS (
+      ID   SERIAL,
+      PET_ID INT8 NOT NULL,
+      SHIP_DATE TIMESTAMP NULL,
+      STATUS VARCHAR NOT NULL,
+      COMPLETE BOOLEAN NOT NULL
+    )
+  """.update.run.transact(xa).unsafeRun
+
+  /* We require type StatusMeta to handle our ADT Status */
+  private implicit val StatusMeta: Meta[OrderStatus] = Meta[String].nxmap(OrderStatus.apply, OrderStatus.nameOf)
+
+  /* We require conversion for date time */
+  private implicit val DateTimeMeta: Meta[DateTime] = Meta[java.sql.Timestamp].nxmap(
+    ts => new DateTime(ts.getTime),
+    dt => new java.sql.Timestamp(dt.getMillis)
+  )
+
+  def put(order: Order): Task[Order] = {
+    val insert: ConnectionIO[Order] =
+      for {
+        id <- sql"REPLACE INTO ORDERS (PET_ID, SHIP_DATE, STATUS, COMPLETE) values (${order.petId}, ${order.shipDate}, ${order.status}, ${order.complete})".update.withUniqueGeneratedKeys[Long]("ID")
+      } yield order.copy(id = Some(id))
+    insert.transact(xa)
+  }
+
+  def get(orderId: Long): Task[Option[Order]] = {
+    sql"""
+      SELECT PET_ID, SHIP_DATE, STATUS, COMPLETE
+        FROM ORDERS
+       WHERE ID = $orderId
+     """.query[Order].option.transact(xa)
+  }
+
+  def delete(orderId: Long): Task[Option[Order]] = {
+    get(orderId).flatMap {
+      case Some(order) =>
+        sql"DELETE FROM ORDERS WHERE ID = $orderId".update.run.transact(xa).map(_ => Some(order))
+      case None =>
+        Task.now(None)
+    }
+  }
+}
+
+object DoobieOrderRepositoryInterpreter {
+  def apply(): DoobieOrderRepositoryInterpreter = {
+    val xa = DriverManagerTransactor[Task]("org.h2.Driver", "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1", "sa", "")
+    new DoobieOrderRepositoryInterpreter(xa)
+  }
+}

--- a/src/main/scala/io/github/pauljamescleary/petstore/repository/DoobiePetRepositoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/repository/DoobiePetRepositoryInterpreter.scala
@@ -31,7 +31,7 @@ class DoobiePetRepositoryInterpreter(val xa: Transactor[Task]) extends PetReposi
     )
   """.update.run.transact(xa).unsafeRun
 
-  /* We require tye StatusMeta to handle our ADT Status */
+  /* We require type StatusMeta to handle our ADT Status */
   private implicit val StatusMeta: Meta[Status] = Meta[String].nxmap(Status.apply, Status.nameOf)
 
   /* This is used to marshal our sets of strings */

--- a/src/main/scala/io/github/pauljamescleary/petstore/repository/OrderRepositoryAlgebra.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/repository/OrderRepositoryAlgebra.scala
@@ -1,0 +1,14 @@
+package io.github.pauljamescleary.petstore.repository
+
+import io.github.pauljamescleary.petstore.model.Order
+
+import scala.language.higherKinds
+
+trait OrderRepositoryAlgebra[F[_]] {
+
+  def put(order: Order): F[Order]
+
+  def get(orderId: Long): F[Option[Order]]
+
+  def delete(orderId: Long): F[Option[Order]]
+}

--- a/src/main/scala/io/github/pauljamescleary/petstore/repository/PetRepositoryAlgebra.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/repository/PetRepositoryAlgebra.scala
@@ -1,6 +1,6 @@
 package io.github.pauljamescleary.petstore.repository
 
-import io.github.pauljamescleary.petstore.model.{Category, Pet}
+import io.github.pauljamescleary.petstore.model.Pet
 
 import scala.language.higherKinds
 

--- a/src/main/scala/io/github/pauljamescleary/petstore/repository/PetRepositoryInMemoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/repository/PetRepositoryInMemoryInterpreter.scala
@@ -1,7 +1,7 @@
 package io.github.pauljamescleary.petstore.repository
 
 import fs2.Task
-import io.github.pauljamescleary.petstore.model.{Category, Pet}
+import io.github.pauljamescleary.petstore.model.Pet
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Random

--- a/src/main/scala/io/github/pauljamescleary/petstore/service/OrderService.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/service/OrderService.scala
@@ -1,0 +1,12 @@
+package io.github.pauljamescleary.petstore.service
+
+import fs2.util.Monad
+import io.github.pauljamescleary.petstore.model.Order
+import io.github.pauljamescleary.petstore.repository.OrderRepositoryAlgebra
+
+import scala.language.higherKinds
+
+class OrderService[F[_] : Monad](implicit val orderRepo: OrderRepositoryAlgebra[F]) {
+
+  def placeOrder(order: Order): F[Order] = orderRepo.put(order)
+}


### PR DESCRIPTION
I am unclear on the motivation as having these be their own types
instead of just strings.  We can index on strings and get query access
patterns that we need.

Deleting these for the time being