### PR TITLE
Forward functional test exit status to travis, fix exit status variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,9 +38,9 @@ done
 echo "Server started, running func tests"
 cd functional_test
 ./run.py live_tests -v
-FUNC_TEST_RESULT=$!
+FUNC_TEST_RESULT=$?
 
-echo "Functional tests completed with satus $FUNC_TEST_RESULT, stopping server with PID $SERVER_PID, PPID $PARENT_PID"
+echo "Functional tests completed with status $FUNC_TEST_RESULT, stopping server with PID $SERVER_PID, PPID $PARENT_PID"
 
 kill $SERVER_PID
 wait $SERVER_PID
@@ -49,4 +49,5 @@ wait $SERVER_PID
 # kill -9 $PARENT_PID
 
 echo "DONE!"
-exit 0
+exit $FUNC_TEST_RESULT
+


### PR DESCRIPTION
Some simple typos led to the functional tests output result not being forwarded back to travis. So failed functional tests would appear as passed in the travis output on github.
