### PR TITLE
Use .as instead of .map to replace inner value in a functor

### DIFF
--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetService.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetService.scala
@@ -39,7 +39,7 @@ class PetService[F[_]](repository: PetRepositoryAlgebra[F], validation: PetValid
 
   /* In some circumstances we may care if we actually delete the pet; here we are idempotent and do not care */
   def delete(id: Long)(implicit M: Monad[F]): F[Unit] =
-    repository.delete(id).map(_ => ())
+    repository.delete(id).as(())
 
   def list(pageSize: Int, offset: Int): F[List[Pet]] =
     repository.list(pageSize, offset)

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/users/UserService.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/users/UserService.scala
@@ -34,7 +34,7 @@ class UserService[F[_]](userRepo: UserRepositoryAlgebra[F], validation: UserVali
   def deleteUser(userId: Long): F[Option[User]] = userRepo.delete(userId)
 
   def deleteByName(userName: String)(implicit M: Monad[F]): F[Unit] =
-    userRepo.deleteByUserName(userName).map(_ => ())
+    userRepo.deleteByUserName(userName).as(())
 
   def update(user: User)(implicit M: Monad[F]): EitherT[F, UserNotFoundError.type, User] =
     for {

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobieOrderRepositoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobieOrderRepositoryInterpreter.scala
@@ -50,7 +50,7 @@ class DoobieOrderRepositoryInterpreter[F[_]: Monad](val xa: Transactor[F])
 
   def delete(orderId: Long): F[Option[Order]] =
     OptionT(get(orderId)).semiflatMap(order =>
-      OrderSQL.delete(orderId).run.transact(xa).map(_ => order)
+      OrderSQL.delete(orderId).run.transact(xa).as(order)
     ).value
 }
 

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobiePetRepositoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobiePetRepositoryInterpreter.scala
@@ -74,7 +74,7 @@ class DoobiePetRepositoryInterpreter[F[_]: Monad](val xa: Transactor[F])
   def get(id: Long): F[Option[Pet]] = select(id).option.transact(xa)
 
   def delete(id: Long): F[Option[Pet]] = OptionT(get(id)).semiflatMap(pet =>
-    PetSQL.delete(id).run.transact(xa).map(_ => pet)
+    PetSQL.delete(id).run.transact(xa).as(pet)
   ).value
 
   def findByNameAndCategory(name: String, category: String): F[Set[Pet]] =


### PR DESCRIPTION
This is a common enough operation that we should use what cats
gives us, `.as` instead of `.map` for the use `.as(v)` instead of
`.map(_ => v)`