### PR TITLE
Update put endpoints to take key where the update should occur

### DIFF
--- a/functional_test/pet_store_client.py
+++ b/functional_test/pet_store_client.py
@@ -40,7 +40,7 @@ class PetStoreClient(object):
         :param pet:
         :return:
         """
-        url = urljoin(self.index_url, '/pets')
+        url = urljoin(self.index_url, "/pets/{0}".format(pet['id']))
 
         return self.session.request('PUT', url, self.headers, json.dumps(pet))
 

--- a/functional_test/pet_store_client.py
+++ b/functional_test/pet_store_client.py
@@ -138,7 +138,7 @@ class PetStoreClient(object):
         :param user:
         :return:
         """
-        url = urljoin(self.index_url, '/users')
+        url = urljoin(self.index_url, "/users/{0}".format(user['userName']))
 
         return self.session.request('PUT', url, self.headers, json.dumps(user))
 

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpoints.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpoints.scala
@@ -53,9 +53,10 @@ class PetEndpoints[F[_]: Effect] extends Http4sDsl[F] {
 
   private def updatePetEndpoint(petService: PetService[F]): HttpService[F] =
     HttpService[F] {
-      case req @ PUT -> Root / "pets" =>
+      case req @ PUT -> Root / "pets" / LongVar(petId) =>
         val action = for {
           pet <- req.as[Pet]
+          updated = pet.copy(id = Some(petId))
           result <- petService.update(pet).value
         } yield result
 

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/UserEndpoints.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/UserEndpoints.scala
@@ -35,10 +35,11 @@ class UserEndpoints[F[_]: Effect] extends Http4sDsl[F] {
 
   private def updateEndpoint(userService: UserService[F]): HttpService[F] =
     HttpService[F] {
-      case req @ PUT -> Root / "users" =>
+      case req @ PUT -> Root / "users" / name =>
         val action = for {
           user <- req.as[User]
-          result <- userService.update(user).value
+          updated = user.copy(userName = name)
+          result <- userService.update(updated).value
         } yield result
 
         action.flatMap {

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
@@ -64,7 +64,7 @@ class PetEndpointsSpec
           .getOrElse(fail(s"Request was not handled: $createRequest"))
         createdPet <- createResponse.as[Pet]
         petToUpdate = createdPet.copy(name = createdPet.name.reverse)
-        updateRequest <- Request[IO](Method.PUT, Uri.uri("/pets"))
+        updateRequest <- Request[IO](Method.PUT, Uri.unsafeFromString(s"/pets/${petToUpdate.id.get}"))
           .withBody(petToUpdate.asJson)
         updateResponse <- petHttpService
           .run(updateRequest)

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/UserEndpointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/UserEndpointsSpec.scala
@@ -56,8 +56,8 @@ class UserEndpointsSpec
           .run(createRequest)
           .getOrElse(fail(s"Request was not handled: $createRequest"))
         createdUser <- createResponse.as[User]
-        userToUpdate = createdUser.copy(userName = createdUser.userName.reverse)
-        updateUser <- Request[IO](Method.PUT, Uri.uri("/users"))
+        userToUpdate = createdUser.copy(lastName = createdUser.lastName.reverse)
+        updateUser <- Request[IO](Method.PUT, Uri.unsafeFromString(s"/users/${createdUser.userName}"))
           .withBody(userToUpdate.asJson)
         updateResponse <- userHttpService
           .run(updateUser)


### PR DESCRIPTION
Previously, we were running PUT to /users

In order to update a user, we should PUT to /users/<userName>

Modify the put pet endpoint to put onto the pet id as well