### PR TITLE
Fix flyway migration to remove doobie transactor argument

### DIFF
--- a/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
@@ -18,38 +18,34 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object Server extends IOApp {
   private val keyGen = HMACSHA256
 
-  def createServer[F[_] : ContextShift : ConcurrentEffect : Timer]: F[ExitCode] =
+  def createServer[F[_] : ContextShift : ConcurrentEffect : Timer]: Resource[F, ExitCode] =
     for {
-      conf           <- PetStoreConfig.load[F]
-      signingKey     <- keyGen.generateKey[F]
-      xar            =  DatabaseConfig.dbTransactor(conf.db, global, global)
-      exitCode       <- xar.use { xa =>
-        val petRepo        =  DoobiePetRepositoryInterpreter[F](xa)
-        val orderRepo      =  DoobieOrderRepositoryInterpreter[F](xa)
-        val userRepo       =  DoobieUserRepositoryInterpreter[F](xa)
-        val petValidation  =  PetValidationInterpreter[F](petRepo)
-        val petService     =  PetService[F](petRepo, petValidation)
-        val userValidation =  UserValidationInterpreter[F](userRepo)
-        val orderService   =  OrderService[F](orderRepo)
-        val userService    =  UserService[F](userRepo, userValidation)
-        val services       =  PetEndpoints.endpoints[F](petService) <+>
-                              OrderEndpoints.endpoints[F](orderService) <+>
-                              UserEndpoints.endpoints[F, BCrypt](userService, BCrypt.syncPasswordHasher[F])
-        val httpApp = Router("/" -> services).orNotFound
-
-        val init : F[Unit] = xa.configure(DatabaseConfig.initializeDb(_))
-
-        val build : F[ExitCode] = BlazeServerBuilder[F]
-          .bindHttp(8080, "localhost")
-          .withHttpApp(httpApp)
-          .serve
-          .compile
-          .drain
-          .as(ExitCode.Success)
-
-        init *> build
-      }
+      conf           <- Resource.liftF(PetStoreConfig.load[F])
+      signingKey     <- Resource.liftF(keyGen.generateKey[F])
+      xa             <- DatabaseConfig.dbTransactor(conf.db, global, global)
+      petRepo        =  DoobiePetRepositoryInterpreter[F](xa)
+      orderRepo      =  DoobieOrderRepositoryInterpreter[F](xa)
+      userRepo       =  DoobieUserRepositoryInterpreter[F](xa)
+      petValidation  =  PetValidationInterpreter[F](petRepo)
+      petService     =  PetService[F](petRepo, petValidation)
+      userValidation =  UserValidationInterpreter[F](userRepo)
+      orderService   =  OrderService[F](orderRepo)
+      userService    =  UserService[F](userRepo, userValidation)
+      services       =  PetEndpoints.endpoints[F](petService) <+>
+                            OrderEndpoints.endpoints[F](orderService) <+>
+                            UserEndpoints.endpoints[F, BCrypt](userService, BCrypt.syncPasswordHasher[F])
+      httpApp = Router("/" -> services).orNotFound
+      _ <- Resource.liftF(xa.configure(DatabaseConfig.initializeDb(_)))
+      exitCode <- Resource.liftF(
+        BlazeServerBuilder[F]
+        .bindHttp(8080, "localhost")
+        .withHttpApp(httpApp)
+        .serve
+        .compile
+        .drain
+        .as(ExitCode.Success)
+      )
     } yield exitCode
 
-  def run(args : List[String]) : IO[ExitCode] = createServer[IO]
+  def run(args : List[String]) : IO[ExitCode] = createServer.use(IO.pure)
 }

--- a/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
@@ -35,7 +35,7 @@ object Server extends IOApp {
                             OrderEndpoints.endpoints[F](orderService) <+>
                             UserEndpoints.endpoints[F, BCrypt](userService, BCrypt.syncPasswordHasher[F])
       httpApp = Router("/" -> services).orNotFound
-      _ <- Resource.liftF(xa.configure(DatabaseConfig.initializeDb(_)))
+      _ <- Resource.liftF(DatabaseConfig.initializeDb(conf.db))
       exitCode <- Resource.liftF(
         BlazeServerBuilder[F]
         .bindHttp(8080, "localhost")

--- a/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
@@ -2,7 +2,6 @@ package io.github.pauljamescleary.petstore.config
 
 import cats.effect.{Async, ContextShift, Resource, Sync}
 import doobie.hikari.HikariTransactor
-import javax.sql.DataSource
 import org.flywaydb.core.Flyway
 
 import scala.concurrent.ExecutionContext
@@ -20,10 +19,11 @@ object DatabaseConfig {
   /**
     * Runs the flyway migrations against the target database
     */
-  def initializeDb[F[_]](ds: DataSource)(implicit S: Sync[F]): F[Unit] =
+  def
+  initializeDb[F[_]](cfg : DatabaseConfig)(implicit S: Sync[F]): F[Unit] =
     S.delay {
       val fw = new Flyway()
-      fw.setDataSource(ds)
+      fw.setDataSource(cfg.url, cfg.user, cfg.password)
       fw.migrate()
       ()
     }

--- a/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
@@ -19,8 +19,7 @@ object DatabaseConfig {
   /**
     * Runs the flyway migrations against the target database
     */
-  def
-  initializeDb[F[_]](cfg : DatabaseConfig)(implicit S: Sync[F]): F[Unit] =
+  def initializeDb[F[_]](cfg : DatabaseConfig)(implicit S: Sync[F]): F[Unit] =
     S.delay {
       val fw = new Flyway()
       fw.setDataSource(cfg.url, cfg.user, cfg.password)

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
@@ -4,7 +4,6 @@ import cats.implicits._
 import cats.effect.{Async, ContextShift, Effect, IO}
 import io.github.pauljamescleary.petstore.config.{DatabaseConfig, PetStoreConfig}
 import _root_.doobie.Transactor
-import javax.sql.DataSource
 
 import scala.concurrent.ExecutionContext
 
@@ -18,22 +17,11 @@ package object doobie {
     )
 
   /*
-   * Create an h2 DataSource which flyway can use to initialize the database.
-   */
-  def h2DataSource(cfg : DatabaseConfig) : DataSource = {
-    val ds = new org.h2.jdbcx.JdbcDataSource()
-    ds.setUrl(cfg.url)
-    ds.setUser(cfg.user)
-    ds.setPassword(cfg.password)
-    ds
-  }
-
-  /*
    * Provide a transactor for testing once schema has been migrated.
    */
   def initializedTransactor[F[_] : Effect : Async : ContextShift] : F[Transactor[F]] = for {
     petConfig <- PetStoreConfig.load[F]
-    _ <- DatabaseConfig.initializeDb(h2DataSource(petConfig.db))
+    _ <- DatabaseConfig.initializeDb(petConfig.db)
   } yield getTransactor(petConfig.db)
 
   lazy val testEc = ExecutionContext.Implicits.global

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
@@ -4,6 +4,7 @@ import cats.implicits._
 import cats.effect.{Async, ContextShift, Effect, IO}
 import io.github.pauljamescleary.petstore.config.{DatabaseConfig, PetStoreConfig}
 import _root_.doobie.Transactor
+import javax.sql.DataSource
 
 import scala.concurrent.ExecutionContext
 
@@ -16,12 +17,28 @@ package object doobie {
       cfg.password           // password
     )
 
+  /*
+   * Create an h2 DataSource which flyway can use to initialize the database.
+   */
+  def h2DataSource(cfg : DatabaseConfig) : DataSource = {
+    val ds = new org.h2.jdbcx.JdbcDataSource()
+    ds.setUrl(cfg.url)
+    ds.setUser(cfg.user)
+    ds.setPassword(cfg.password)
+    ds
+  }
+
+  /*
+   * Provide a transactor for testing once schema has been migrated.
+   */
   def initializedTransactor[F[_] : Effect : Async : ContextShift] : F[Transactor[F]] = for {
     petConfig <- PetStoreConfig.load[F]
-    _ <- DatabaseConfig.initializeDb(petConfig.db)
+    _ <- DatabaseConfig.initializeDb(h2DataSource(petConfig.db))
   } yield getTransactor(petConfig.db)
 
   lazy val testEc = ExecutionContext.Implicits.global
+
   implicit lazy val testCs = IO.contextShift(testEc)
+
   lazy val testTransactor = initializedTransactor[IO].unsafeRunSync()
 }


### PR DESCRIPTION
Flyway initiates its own JDBC connection to the database, and then
closes it when the migration is done. There's no reason to require
a HikariTransactor in test just to use its JDBC datasource in order to apply
migrations via Flyway, so we can just create a JDBC datasource from
our configuration and pass it to flyway.