### PR TITLE
Upgrade http4s 0.20 and doobie 0.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 val CatsVersion            = "1.4.0"
 val CirceVersion           = "0.10.1"
-val DoobieVersion          = "0.5.3"
+val DoobieVersion          = "0.6.0"
 val EnumeratumVersion      = "1.5.13"
 val EnumeratumCirceVersion = "1.5.17"
-val H2Version              = "1.4.196"
+val H2Version              = "1.4.197"
 val Http4sVersion          = "0.20.0-M3"
 val LogbackVersion         = "1.2.3"
 val ScalaCheckVersion      = "1.14.0"

--- a/build.sbt
+++ b/build.sbt
@@ -6,15 +6,15 @@ scalaVersion    := "2.12.7"
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 val CatsVersion            = "1.4.0"
-val CirceVersion           = "0.10.0"
+val CirceVersion           = "0.10.1"
 val DoobieVersion          = "0.5.3"
 val EnumeratumVersion      = "1.5.13"
 val EnumeratumCirceVersion = "1.5.17"
 val H2Version              = "1.4.196"
-val Http4sVersion          = "0.18.19"
+val Http4sVersion          = "0.20.0-M3"
 val LogbackVersion         = "1.2.3"
 val ScalaCheckVersion      = "1.14.0"
-val ScalaTestVersion       = "3.0.4"
+val ScalaTestVersion       = "3.0.5"
 val FlywayVersion          = "4.2.0"
 val PureConfigVersion      = "0.9.2"
 val TsecVersion            = "0.0.1-M11"
@@ -24,7 +24,6 @@ libraryDependencies ++= Seq(
   "io.circe"              %% "circe-generic"        % CirceVersion,
   "io.circe"              %% "circe-literal"        % CirceVersion,
   "io.circe"              %% "circe-generic-extras" % CirceVersion,
-  "io.circe"              %% "circe-optics"         % CirceVersion,
   "io.circe"              %% "circe-parser"         % CirceVersion,
   "io.circe"              %% "circe-java8"          % CirceVersion,
   "org.tpolecat"          %% "doobie-core"          % DoobieVersion,
@@ -40,6 +39,7 @@ libraryDependencies ++= Seq(
   "ch.qos.logback"        %  "logback-classic"      % LogbackVersion,
   "org.flywaydb"          %  "flyway-core"          % FlywayVersion,
   "com.github.pureconfig" %% "pureconfig"           % PureConfigVersion,
+  "org.http4s"            %% "http4s-blaze-client"  % Http4sVersion     % Test,
   "org.scalacheck"        %% "scalacheck"           % ScalaCheckVersion % Test,
   "org.scalatest"         %% "scalatest"            % ScalaTestVersion  % Test,
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.6

--- a/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
@@ -14,35 +14,36 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.implicits._
 import tsec.mac.jca.HMACSHA256
 import tsec.passwordhashers.jca.BCrypt
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object Server extends IOApp {
   private val keyGen = HMACSHA256
 
-  def createStream[F[_] : ConcurrentEffect : Timer](args: List[String]): Stream[F, ExitCode] =
+  def createStream[F[_] : ContextShift : ConcurrentEffect : Timer](args: List[String]): Stream[F, ExitCode] =
     for {
       conf           <- Stream.eval(PetStoreConfig.load[F])
       signingKey     <- Stream.eval(keyGen.generateKey[F])
       _              <- Stream.eval(DatabaseConfig.initializeDb(conf.db))
-      xa             <- Stream.eval(DatabaseConfig.dbTransactor(conf.db))
-      petRepo        =  DoobiePetRepositoryInterpreter[F](xa)
-      orderRepo      =  DoobieOrderRepositoryInterpreter[F](xa)
-      userRepo       =  DoobieUserRepositoryInterpreter[F](xa)
-      petValidation  =  PetValidationInterpreter[F](petRepo)
-      petService     =  PetService[F](petRepo, petValidation)
-      userValidation =  UserValidationInterpreter[F](userRepo)
-      orderService   =  OrderService[F](orderRepo)
-      userService    =  UserService[F](userRepo, userValidation)
-      services       =  PetEndpoints.endpoints[F](petService) <+>
-                        OrderEndpoints.endpoints[F](orderService) <+>
-                        UserEndpoints.endpoints[F, BCrypt](userService, BCrypt.syncPasswordHasher[F])
-      httpApp        =  Router("/" -> services).orNotFound
+      xar            <- Stream(DatabaseConfig.dbTransactor(conf.db, global, global)).covary[F]
+      httpApp        <- Stream.eval(xar.use{ xa =>
+        val petRepo        =  DoobiePetRepositoryInterpreter[F](xa)
+        val orderRepo      =  DoobieOrderRepositoryInterpreter[F](xa)
+        val userRepo       =  DoobieUserRepositoryInterpreter[F](xa)
+        val petValidation  =  PetValidationInterpreter[F](petRepo)
+        val petService     =  PetService[F](petRepo, petValidation)
+        val userValidation =  UserValidationInterpreter[F](userRepo)
+        val orderService   =  OrderService[F](orderRepo)
+        val userService    =  UserService[F](userRepo, userValidation)
+        val services       =  PetEndpoints.endpoints[F](petService) <+>
+                              OrderEndpoints.endpoints[F](orderService) <+>
+                              UserEndpoints.endpoints[F, BCrypt](userService, BCrypt.syncPasswordHasher[F])
+        Router("/" -> services).orNotFound.pure[F]
+      })
       exitCode       <- BlazeServerBuilder[F]
                           .bindHttp(8080, "localhost")
                           .withHttpApp(httpApp)
                           .serve
     } yield exitCode
 
-
-  def run(args : List[String]) : IO[ExitCode] =
-    createStream[IO](args).compile.drain.as(ExitCode.Success)
+  def run(args : List[String]) : IO[ExitCode] = createStream[IO](args).compile.drain.as(ExitCode.Success)
 }

--- a/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
@@ -24,7 +24,7 @@ object Server extends IOApp {
       signingKey     <- keyGen.generateKey[F]
       _              <- DatabaseConfig.initializeDb(conf.db)
       xar            =  DatabaseConfig.dbTransactor(conf.db, global, global)
-      exitCode       <- xar.use{ xa =>
+      exitCode       <- xar.use { xa =>
         val petRepo        =  DoobiePetRepositoryInterpreter[F](xa)
         val orderRepo      =  DoobieOrderRepositoryInterpreter[F](xa)
         val userRepo       =  DoobieUserRepositoryInterpreter[F](xa)

--- a/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/Server.scala
@@ -26,8 +26,8 @@ object Server extends StreamApp[IO] {
     for {
       conf           <- Stream.eval(PetStoreConfig.load[F])
       signingKey     <- Stream.eval(keyGen.generateKey[F])
+      _              <- Stream.eval(DatabaseConfig.initializeDb(conf.db))
       xa             <- Stream.eval(DatabaseConfig.dbTransactor(conf.db))
-      _              <- Stream.eval(DatabaseConfig.initializeDb(conf.db, xa))
       petRepo        =  DoobiePetRepositoryInterpreter[F](xa)
       orderRepo      =  DoobieOrderRepositoryInterpreter[F](xa)
       userRepo       =  DoobieUserRepositoryInterpreter[F](xa)

--- a/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
@@ -1,15 +1,20 @@
 package io.github.pauljamescleary.petstore.config
 
-import cats.effect.{Async, Sync}
+import cats.effect.{Async, ContextShift, Resource, Sync}
 import doobie.hikari.HikariTransactor
 import org.flywaydb.core.Flyway
+
+import scala.concurrent.ExecutionContext
 
 case class DatabaseConfig(url: String, driver: String, user: String, password: String)
 
 object DatabaseConfig {
-
-  def dbTransactor[F[_]: Async](dbConfig: DatabaseConfig): F[HikariTransactor[F]] =
-    HikariTransactor.newHikariTransactor[F](dbConfig.driver, dbConfig.url, dbConfig.user, dbConfig.password)
+  def dbTransactor[F[_]: Async : ContextShift](
+    dbc: DatabaseConfig,
+    connEc : ExecutionContext,
+    transEc : ExecutionContext
+  ): Resource[F, HikariTransactor[F]] =
+    HikariTransactor.newHikariTransactor[F](dbc.driver, dbc.url, dbc.user, dbc.password, connEc, transEc)
 
   /**
     * Runs the flyway migrations against the target database

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpoints.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpoints.scala
@@ -22,8 +22,8 @@ class OrderEndpoints[F[_]: Effect] extends Http4sDsl[F] {
   /* Needed to decode entities */
   implicit val orderDecoder = jsonOf[F, Order]
 
-  def placeOrderEndpoint(orderService: OrderService[F]): HttpService[F] =
-    HttpService[F] {
+  def placeOrderEndpoint(orderService: OrderService[F]): HttpRoutes[F] =
+    HttpRoutes.of[F] {
       case req @ POST -> Root / "orders" => {
         for {
           order <- req.as[Order]
@@ -33,8 +33,8 @@ class OrderEndpoints[F[_]: Effect] extends Http4sDsl[F] {
       }
     }
 
-  private def getOrderEndpoint(orderService: OrderService[F]): HttpService[F] =
-    HttpService[F] {
+  private def getOrderEndpoint(orderService: OrderService[F]): HttpRoutes[F] =
+    HttpRoutes.of[F] {
       case GET -> Root / "orders" / LongVar(id) =>
         orderService.get(id).value.flatMap {
           case Right(found) => Ok(found.asJson)
@@ -42,8 +42,8 @@ class OrderEndpoints[F[_]: Effect] extends Http4sDsl[F] {
         }
     }
 
-  private def deleteOrderEndpoint(orderService: OrderService[F]): HttpService[F] =
-    HttpService[F] {
+  private def deleteOrderEndpoint(orderService: OrderService[F]): HttpRoutes[F] =
+    HttpRoutes.of[F] {
       case DELETE -> Root / "orders" / LongVar(id) =>
         for {
           _ <- orderService.delete(id)
@@ -51,11 +51,11 @@ class OrderEndpoints[F[_]: Effect] extends Http4sDsl[F] {
         } yield resp
     }
 
-  def endpoints(orderService: OrderService[F]): HttpService[F] =
+  def endpoints(orderService: OrderService[F]): HttpRoutes[F] =
     placeOrderEndpoint(orderService) <+> getOrderEndpoint(orderService) <+> deleteOrderEndpoint(orderService)
 }
 
 object OrderEndpoints {
-  def endpoints[F[_]: Effect](orderService: OrderService[F]): HttpService[F] =
+  def endpoints[F[_]: Effect](orderService: OrderService[F]): HttpRoutes[F] =
     new OrderEndpoints[F].endpoints(orderService)
 }

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobieOrderRepositoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobieOrderRepositoryInterpreter.scala
@@ -13,14 +13,11 @@ import orders.{OrderRepositoryAlgebra, OrderStatus, Order}
 private object OrderSQL {
   /* We require type StatusMeta to handle our ADT Status */
   implicit val StatusMeta: Meta[OrderStatus] =
-    Meta[String].xmap(OrderStatus.withName, _.entryName)
+    Meta[String].imap(OrderStatus.withName)(_.entryName)
 
   /* We require conversion for date time */
   implicit val DateTimeMeta: Meta[Instant] =
-    Meta[java.sql.Timestamp].xmap(
-      ts => ts.toInstant,
-      dt => java.sql.Timestamp.from(dt)
-    )
+    Meta[java.sql.Timestamp].imap(_.toInstant)(java.sql.Timestamp.from _)
 
   def select(orderId: Long): Query0[Order] = sql"""
     SELECT PET_ID, SHIP_DATE, STATUS, COMPLETE, ID

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobiePetRepositoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/DoobiePetRepositoryInterpreter.scala
@@ -11,11 +11,11 @@ import SQLPagination._
 private object PetSQL {
   /* We require type StatusMeta to handle our ADT Status */
   implicit val StatusMeta: Meta[PetStatus] =
-    Meta[String].xmap(PetStatus.withName, _.entryName)
+    Meta[String].imap(PetStatus.withName)(_.entryName)
 
   /* This is used to marshal our sets of strings */
-  implicit val SetStringMeta: Meta[Set[String]] = Meta[String]
-    .xmap(str => str.split(',').toSet, strSet => strSet.mkString(","))
+  implicit val SetStringMeta: Meta[Set[String]] =
+    Meta[String].imap(_.split(',').toSet)(_.mkString(","))
 
   def insert(pet: Pet) : Update0 = sql"""
     INSERT INTO PET (NAME, CATEGORY, BIO, STATUS, TAGS, PHOTO_URLS)

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/Pagination.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/Pagination.scala
@@ -10,11 +10,11 @@ import doobie.implicits._
   * which seems wrong.
   */
 trait SQLPagination {
-  def limit[A: Composite](lim: Int)(q: Query0[A]): Query0[A] =
-    (q.toFragment ++ sql" LIMIT $lim").query
+  def limit[A: Read](lim: Int)(q: Query0[A]): Query0[A] =
+    (q.toFragment ++ fr"LIMIT $lim").query
 
-  def paginate[A: Composite](lim: Int, offset: Int)(q: Query0[A]): Query0[A] =
-    (q.toFragment ++ sql" LIMIT $lim OFFSET $offset").query
+  def paginate[A: Read](lim: Int, offset: Int)(q: Query0[A]): Query0[A] =
+    (q.toFragment ++ fr"LIMIT $lim OFFSET $offset").query
 }
 
 object SQLPagination extends SQLPagination

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndointsSpec.scala
@@ -4,7 +4,6 @@ import io.github.pauljamescleary.petstore.domain.orders._
 import io.github.pauljamescleary.petstore.PetStoreArbitraries
 import io.github.pauljamescleary.petstore.infrastructure.repository.inmemory.OrderRepositoryInMemoryInterpreter
 import cats.effect._
-//import io.circe.generic.auto._
 import io.circe._
 import io.circe.generic.semiauto._
 import io.circe.java8.time._

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndointsSpec.scala
@@ -4,12 +4,15 @@ import io.github.pauljamescleary.petstore.domain.orders._
 import io.github.pauljamescleary.petstore.PetStoreArbitraries
 import io.github.pauljamescleary.petstore.infrastructure.repository.inmemory.OrderRepositoryInMemoryInterpreter
 import cats.effect._
-import io.circe.generic.auto._
+//import io.circe.generic.auto._
+import io.circe._
+import io.circe.generic.semiauto._
 import io.circe.java8.time._
-import io.circe.syntax._
 import org.http4s._
+import org.http4s.implicits._
 import org.http4s.dsl._
 import org.http4s.circe._
+import org.http4s.client.dsl.Http4sClientDsl
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 
@@ -19,22 +22,24 @@ class OrderEndpointsSpec
     with Matchers
     with PropertyChecks
     with PetStoreArbitraries
-    with Http4sDsl[IO] {
+    with Http4sDsl[IO]
+    with Http4sClientDsl[IO] {
+
+  implicit val statusDec : EntityDecoder[IO, OrderStatus] = jsonOf
+  implicit val statusEnc : EntityEncoder[IO, OrderStatus] = jsonEncoderOf
+
+  implicit val orderEncoder : Encoder[Order] = deriveEncoder
+  implicit val orderEnc : EntityEncoder[IO, Order] = jsonEncoderOf
 
   test("place order") {
 
     val orderService = OrderService(OrderRepositoryInMemoryInterpreter[IO]())
-    val orderHttpService = OrderEndpoints.endpoints[IO](orderService)
+    val orderHttpService = OrderEndpoints.endpoints[IO](orderService).orNotFound
 
     forAll { (order: Order) =>
-      val placeOrderReq =
-        Request[IO](Method.POST, Uri.uri("/orders")).withBody(order.asJson)
-
       (for {
-        request <- placeOrderReq
-        response <- orderHttpService
-          .run(request)
-          .getOrElse(fail(s"Request was not handled: $request"))
+        request <- POST(order, Uri.uri("/orders"))
+        response <- orderHttpService.run(request)
       } yield {
         response.status shouldEqual Ok
       }).unsafeRunSync

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
@@ -7,7 +7,6 @@ import cats.effect._
 
 import io.circe.generic.auto._
 
-//import io.circe.generic.semiauto._
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.dsl._
@@ -25,8 +24,6 @@ class PetEndpointsSpec
     with Http4sDsl[IO]
     with Http4sClientDsl[IO]{
 
-//  implicit val petEncoder : Encoder[Pet] = deriveEncoder
-//  implicit val petDecoder : Decoder[Pet] = deriveDecoder
   implicit val petEnc : EntityEncoder[IO, Pet] = jsonEncoderOf
   implicit val petDec : EntityDecoder[IO, Pet] = jsonOf
 

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
@@ -4,11 +4,15 @@ import io.github.pauljamescleary.petstore.domain.pets._
 import io.github.pauljamescleary.petstore.PetStoreArbitraries
 import io.github.pauljamescleary.petstore.infrastructure.repository.inmemory._
 import cats.effect._
-import io.circe.syntax._
+
 import io.circe.generic.auto._
+
+//import io.circe.generic.semiauto._
 import org.http4s._
+import org.http4s.implicits._
 import org.http4s.dsl._
 import org.http4s.circe._
+import org.http4s.client.dsl.Http4sClientDsl
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 
@@ -18,22 +22,25 @@ class PetEndpointsSpec
     with Matchers
     with PropertyChecks
     with PetStoreArbitraries
-    with Http4sDsl[IO] {
+    with Http4sDsl[IO]
+    with Http4sClientDsl[IO]{
+
+//  implicit val petEncoder : Encoder[Pet] = deriveEncoder
+//  implicit val petDecoder : Decoder[Pet] = deriveDecoder
+  implicit val petEnc : EntityEncoder[IO, Pet] = jsonEncoderOf
+  implicit val petDec : EntityDecoder[IO, Pet] = jsonOf
 
   test("create pet") {
 
     val petRepo = PetRepositoryInMemoryInterpreter[IO]()
     val petValidation = PetValidationInterpreter[IO](petRepo)
     val petService = PetService[IO](petRepo, petValidation)
-    val petHttpService = PetEndpoints.endpoints[IO](petService)
+    val petHttpService = PetEndpoints.endpoints[IO](petService).orNotFound
 
     forAll { (pet: Pet) =>
       (for {
-        request <- Request[IO](Method.POST, Uri.uri("/pets"))
-          .withBody(pet.asJson)
-        response <- petHttpService
-          .run(request)
-          .getOrElse(fail(s"Request was not handled: $request"))
+        request <- POST(pet, Uri.uri("/pets"))
+        response <- petHttpService.run(request)
       } yield {
         response.status shouldEqual Ok
       }).unsafeRunSync
@@ -46,24 +53,16 @@ class PetEndpointsSpec
     val petRepo = PetRepositoryInMemoryInterpreter[IO]()
     val petValidation = PetValidationInterpreter[IO](petRepo)
     val petService = PetService[IO](petRepo, petValidation)
-    val petHttpService = PetEndpoints.endpoints[IO](petService)
-
-    implicit val petDecoder = jsonOf[IO, Pet]
+    val petHttpService = PetEndpoints.endpoints[IO](petService).orNotFound
 
     forAll { (pet: Pet) =>
       (for {
-        createRequest <- Request[IO](Method.POST, Uri.uri("/pets"))
-          .withBody(pet.asJson)
-        createResponse <- petHttpService
-          .run(createRequest)
-          .getOrElse(fail(s"Request was not handled: $createRequest"))
+        createRequest <- POST(pet, Uri.uri("/pets"))
+        createResponse <- petHttpService.run(createRequest)
         createdPet <- createResponse.as[Pet]
         petToUpdate = createdPet.copy(name = createdPet.name.reverse)
-        updateRequest <- Request[IO](Method.PUT, Uri.unsafeFromString(s"/pets/${petToUpdate.id.get}"))
-          .withBody(petToUpdate.asJson)
-        updateResponse <- petHttpService
-          .run(updateRequest)
-          .getOrElse(fail(s"Request was not handled: $updateRequest"))
+        updateRequest <- PUT(petToUpdate, Uri.unsafeFromString(s"/pets/${petToUpdate.id.get}"))
+        updateResponse <- petHttpService.run(updateRequest)
         updatedPet <- updateResponse.as[Pet]
       } yield {
         updatedPet.name shouldEqual pet.name.reverse

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
@@ -8,7 +8,7 @@ package object doobie {
   def getTransactor : IO[Transactor[IO]] = for {
     conf <- PetStoreConfig.load[IO]
     tr <- DatabaseConfig.dbTransactor[IO](conf.db)
-    x <- DatabaseConfig.initializeDb(conf.db, tr)
+    x <- DatabaseConfig.initializeDb[IO](conf.db)
   } yield tr
 
   lazy val testTransactor : Transactor[IO] = getTransactor.unsafeRunSync()

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/repository/doobie/package.scala
@@ -1,15 +1,27 @@
 package io.github.pauljamescleary.petstore.infrastructure.repository
 
-import cats.effect.IO
+import cats.implicits._
+import cats.effect.{Async, ContextShift, Effect, IO}
 import io.github.pauljamescleary.petstore.config.{DatabaseConfig, PetStoreConfig}
 import _root_.doobie.Transactor
 
-package object doobie {
-  def getTransactor : IO[Transactor[IO]] = for {
-    conf <- PetStoreConfig.load[IO]
-    tr <- DatabaseConfig.dbTransactor[IO](conf.db)
-    x <- DatabaseConfig.initializeDb[IO](conf.db)
-  } yield tr
+import scala.concurrent.ExecutionContext
 
-  lazy val testTransactor : Transactor[IO] = getTransactor.unsafeRunSync()
+package object doobie {
+  def getTransactor[F[_] : Async : ContextShift](cfg : DatabaseConfig) : Transactor[F] =
+    Transactor.fromDriverManager[F](
+      cfg.driver, // driver classname
+      cfg.url, // connect URL (driver-specific)
+      cfg.user,              // user
+      cfg.password           // password
+    )
+
+  def initializedTransactor[F[_] : Effect : Async : ContextShift] : F[Transactor[F]] = for {
+    petConfig <- PetStoreConfig.load[F]
+    _ <- DatabaseConfig.initializeDb(petConfig.db)
+  } yield getTransactor(petConfig.db)
+
+  lazy val testEc = ExecutionContext.Implicits.global
+  implicit lazy val testCs = IO.contextShift(testEc)
+  lazy val testTransactor = initializedTransactor[IO].unsafeRunSync()
 }


### PR DESCRIPTION
Upgraded http4s partially via https://http4s.org/v0.20/upgrading/, using scalafix.  A number of other issues spring up, most notably that doobie 0.6.0 and http4s 0.20 must be upgraded together due to evicted dependency issues.

**This depends on / includes #102** .

A few adjustments were made in the scala client tests. Using the Http4sClientDsl[F[_]], we get much better syntax on creating requests.