### PR TITLE
kind-projector is published from the typelevel org now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val DoobieVersion          = "0.7.0"
 val EnumeratumCirceVersion = "1.5.21"
 val H2Version              = "1.4.199"
 val Http4sVersion          = "0.20.1"
-val KindProjectorVersion   = "0.9.9"
+val KindProjectorVersion   = "0.10.2"
 val LogbackVersion         = "1.2.3"
 val ScalaCheckVersion      = "1.14.0"
 val ScalaTestVersion       = "3.0.7"
@@ -113,7 +113,7 @@ def scalacOptionsForVersion(version: String): Seq[String] = {
 
 scalacOptions ++= scalacOptionsForVersion(scalaVersion.value)
 
-addCompilerPlugin("org.spire-math" %% "kind-projector" % KindProjectorVersion cross CrossVersion.binary)
+addCompilerPlugin("org.typelevel" %% "kind-projector" % KindProjectorVersion cross CrossVersion.binary)
 
 // Filter out compiler flags to make the repl experience functional...
 val badConsoleFlags = Seq("-Xfatal-warnings", "-Ywarn-unused:imports")


### PR DESCRIPTION
having this merged will be a minor help to the Scala community build,
which assumes the new org