### PR TITLE
Remove circe java8 dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ libraryDependencies ++= Seq(
   "io.circe"              %% "circe-literal"          % CirceVersion,
   "io.circe"              %% "circe-generic-extras"   % CirceVersion,
   "io.circe"              %% "circe-parser"           % CirceVersion,
-  "io.circe"              %% "circe-java8"            % CirceVersion,
   "io.circe"              %% "circe-config"           % CirceConfigVersion,
   "org.tpolecat"          %% "doobie-core"            % DoobieVersion,
   "org.tpolecat"          %% "doobie-h2"              % DoobieVersion,


### PR DESCRIPTION
We're not using this dependency.