### PR TITLE
Add mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,10 @@
+pull_request_rules:
+  - name: automatically merge scala-steward's PRs
+    conditions:
+      - author=scala-steward
+      - status-success=Travis CI - Pull Request
+    actions:
+      merge:
+        method: merge
+      label:
+        add: [dependency-update]


### PR DESCRIPTION
This is a direct copy from [scala-steward's own configuration](https://github.com/fthomas/scala-steward/blob/ce76c18a074b93697f55c44161830a0b2529c75d/.mergify.yml)

If a PR is sent from scala-steward, and passes CI, then it's automatically merged, and the dependency-update label is applied.

This will require @pauljamescleary installing mergify on his github account (free for open source), and enabling on this repo.

[mergify.io](https://mergify.io)
