### PR TITLE
Use new API instead of the deprecated one

### DIFF
--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/LoginTest.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/LoginTest.scala
@@ -7,7 +7,8 @@ import domain.authentication.{LoginRequest, SignupRequest}
 import domain.users.{Role, User}
 import org.http4s.circe.{jsonEncoderOf, jsonOf}
 import org.http4s.client.dsl.Http4sClientDsl
-import org.http4s.{EntityDecoder, EntityEncoder, HttpApp, Request, Response, Uri}
+import org.http4s.{EntityDecoder, EntityEncoder, HttpApp, Request, Response}
+import org.http4s.implicits._
 import org.http4s.headers.Authorization
 import io.circe.generic.auto._
 import org.http4s.dsl.Http4sDsl
@@ -28,11 +29,11 @@ trait LoginTest extends Http4sClientDsl[IO] with Http4sDsl[IO] {
       userEndpoint: HttpApp[IO],
   ): IO[(User, Option[Authorization])] =
     for {
-      signUpRq <- POST(userSignUp, Uri.uri("/users"))
+      signUpRq <- POST(userSignUp, uri"/users")
       signUpResp <- userEndpoint.run(signUpRq)
       user <- signUpResp.as[User]
       loginBody = LoginRequest(userSignUp.userName, userSignUp.password)
-      loginRq <- POST(loginBody, Uri.uri("/users/login"))
+      loginRq <- POST(loginBody, uri"/users/login")
       loginResp <- userEndpoint.run(loginRq)
     } yield {
       user -> loginResp.headers.get(Authorization)

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpointsSpec.scala
@@ -49,7 +49,7 @@ class OrderEndpointsSpec
 
     forAll { (order: Order, user: AdminUser) =>
       (for {
-        createRq <- POST(order, Uri.uri("/orders"))
+        createRq <- POST(order, uri"/orders")
         createRqAuth <- auth.embedToken(user.value, createRq)
         createResp <- orderRoutes.run(createRqAuth)
         orderResp <- createResp.as[Order]

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpointsSpec.scala
@@ -46,7 +46,7 @@ class PetEndpointsSpec
 
     forAll { pet: Pet =>
       (for {
-        request <- POST(pet, Uri.uri("/pets"))
+        request <- POST(pet, uri"/pets")
         response <- petRoutes.run(request)
       } yield {
         response.status shouldEqual Unauthorized
@@ -55,7 +55,7 @@ class PetEndpointsSpec
 
     forAll { (pet: Pet, user: User) =>
       (for {
-        request <- POST(pet, Uri.uri("/pets"))
+        request <- POST(pet, uri"/pets")
           .flatMap(auth.embedToken(user, _))
         response <- petRoutes.run(request)
       } yield {
@@ -65,7 +65,7 @@ class PetEndpointsSpec
 
     forAll { (pet: Pet, user: User) =>
       (for {
-        createRq <- POST(pet, Uri.uri("/pets"))
+        createRq <- POST(pet, uri"/pets")
           .flatMap(auth.embedToken(user, _))
         response <- petRoutes.run(createRq)
         createdPet <- response.as[Pet]
@@ -85,7 +85,7 @@ class PetEndpointsSpec
 
     forAll { (pet: Pet, user: AdminUser) =>
       (for {
-        createRequest <- POST(pet, Uri.uri("/pets"))
+        createRequest <- POST(pet, uri"/pets")
           .flatMap(auth.embedToken(user.value, _))
         createResponse <- petRoutes.run(createRequest)
         createdPet <- createResponse.as[Pet]
@@ -106,7 +106,7 @@ class PetEndpointsSpec
 
     forAll { (pet: Pet, user: AdminUser) =>
       (for {
-        createRequest <- POST(pet, Uri.uri("/pets"))
+        createRequest <- POST(pet, uri"/pets")
           .flatMap(auth.embedToken(user.value, _))
         createResponse <- petRoutes.run(createRequest)
         createdPet <- createResponse.as[Pet]


### PR DESCRIPTION
[`Uri.uri` was deprecated](https://github.com/http4s/http4s/blob/v0.21.0-M5/core/src/main/scala/org/http4s/Uri.scala#L736). It suggests the API with string interpolation.
