### PR TITLE
Adding an FS2 example for simple order processing

### DIFF
--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/orders/OrderProcessor.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/orders/OrderProcessor.scala
@@ -1,0 +1,47 @@
+package io.github.pauljamescleary.petstore.domain.orders
+
+import cats.Monad
+import cats.data.OptionT
+import cats.effect.Timer
+import cats.implicits._
+import fs2.{Pipe, Stream}
+import io.github.pauljamescleary.petstore.domain.orders.OrderRequest.{Cancel, Submit}
+
+import scala.concurrent.duration._
+
+object OrderProcessor {
+
+  def poll[F[_]: Monad: Timer](
+                                interval: FiniteDuration,
+                                queue: OrderQueueAlgebra[F],
+  ): Stream[F, OrderRequest] =
+    Stream.fixedDelay(interval).covary[F].flatMap { _ =>
+      // Fun facts: Option is a Seq, and None is Seq.empty
+      Stream.evalSeq(queue.receive().map(_.toSeq))
+    }
+
+  def handleOrder[F[_]: Monad](
+      repo: OrderRepositoryAlgebra[F],
+  ): Pipe[F, OrderRequest, OrderRequest] =
+    _.evalMap { req =>
+      req match {
+        case Submit(order, _) =>
+          repo.create(order).as(req)
+        case Cancel(order, _) =>
+          OptionT.fromOption[F](order.id).semiflatMap(repo.delete).value.as(req)
+      }
+    }
+
+  def cleanupMessage[F[_]: Monad](queue: OrderQueueAlgebra[F]): Pipe[F, OrderRequest, Unit] =
+    _.evalMap { req =>
+      queue.delete(req.id).void
+    }
+
+  def flow[F[_]: Monad: Timer](
+                                repo: OrderRepositoryAlgebra[F],
+                                queue: OrderQueueAlgebra[F],
+  ): Stream[F, Unit] =
+    poll(5.seconds, queue)
+      .through(handleOrder(repo))
+      .through(cleanupMessage(queue))
+}

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/orders/OrderQueueAlgebra.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/orders/OrderQueueAlgebra.scala
@@ -1,0 +1,18 @@
+package io.github.pauljamescleary.petstore.domain.orders
+
+import java.util.UUID
+
+sealed trait OrderRequest {
+  def id: OrderRequest.RequestId
+}
+object OrderRequest {
+  type RequestId = UUID
+  final case class Submit(order: Order, id: RequestId = UUID.randomUUID()) extends OrderRequest
+  final case class Cancel(order: Order, id: RequestId = UUID.randomUUID()) extends OrderRequest
+}
+
+trait OrderQueueAlgebra[F[_]] {
+  def send[A <: OrderRequest](cmd: A): F[Unit]
+  def receive(): F[Option[OrderRequest]]
+  def delete(id: OrderRequest.RequestId): F[Option[OrderRequest]]
+}

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpoints.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpoints.scala
@@ -42,10 +42,10 @@ class OrderEndpoints[F[_]: Sync, Auth: JWTMacAlgo] extends Http4sDsl[F] {
 
   private def deleteOrderEndpoint(orderService: OrderService[F]): AuthEndpoint[F, Auth] = {
     case DELETE -> Root / LongVar(id) asAuthed _ =>
-      for {
-        _ <- orderService.delete(id)
-        resp <- Ok()
-      } yield resp
+      orderService.cancel(id).value.flatMap {
+        case Right(_) => Ok()
+        case Left(OrderNotFoundError) => NotFound("The order was not found")
+      }
   }
 
   def endpoints(

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/queue/inmemory/OrderQueueInMemoryInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/queue/inmemory/OrderQueueInMemoryInterpreter.scala
@@ -1,0 +1,37 @@
+package io.github.pauljamescleary.petstore.infrastructure.queue.inmemory
+
+import java.util.UUID
+
+import cats.Applicative
+import cats.data.OptionT
+import cats.implicits._
+import io.github.pauljamescleary.petstore.domain.orders.{OrderQueueAlgebra, OrderRequest}
+import io.github.pauljamescleary.petstore.infrastructure.queue.inmemory.OrderQueueInMemoryInterpreter.QueueEntry
+
+import scala.collection.concurrent.TrieMap
+
+class OrderQueueInMemoryInterpreter[F[_]: Applicative] extends OrderQueueAlgebra[F] {
+  private val q = new TrieMap[UUID, QueueEntry]
+
+  def send[A <: OrderRequest](cmd: A): F[Unit] =
+    OptionT.fromOption[F](q.put(cmd.id, QueueEntry(cmd))).value.void
+
+  def receive(): F[Option[OrderRequest]] =
+    OptionT
+      .fromOption[F] {
+        for {
+          avail <- q.values.find(!_.inFlight)
+          claimed = avail.copy(inFlight = true)
+          _ <- q.put(claimed.req.id, claimed)
+        } yield claimed.req
+      }
+      .value
+
+  def delete(id: UUID): F[Option[OrderRequest]] =
+    OptionT.fromOption[F](q.remove(id).map(_.req)).value
+}
+object OrderQueueInMemoryInterpreter {
+  final case class QueueEntry(req: OrderRequest, inFlight: Boolean = false)
+
+  def apply[F[_]: Applicative](): OrderQueueAlgebra[F] = new OrderQueueInMemoryInterpreter[F]
+}

--- a/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpointsSpec.scala
+++ b/src/test/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/OrderEndpointsSpec.scala
@@ -3,6 +3,7 @@ package infrastructure.endpoint
 
 import domain.orders._
 import infrastructure.repository.inmemory._
+import infrastructure.queue.inmemory._
 import cats.effect._
 import io.circe._
 import io.circe.generic.semiauto._
@@ -36,7 +37,7 @@ class OrderEndpointsSpec
   def getTestResources(): (AuthTest[IO], HttpApp[IO]) = {
     val userRepo = UserRepositoryInMemoryInterpreter[IO]()
     val auth = new AuthTest[IO](userRepo)
-    val orderService = OrderService(OrderRepositoryInMemoryInterpreter[IO]())
+    val orderService = OrderService(OrderRepositoryInMemoryInterpreter[IO](), OrderQueueInMemoryInterpreter[IO]())
     val orderEndpoint =
       OrderEndpoints.endpoints[IO, HMACSHA256](orderService, auth.securedRqHandler)
     val orderRoutes = Router(("/orders", orderEndpoint)).orNotFound


### PR DESCRIPTION
Introduces a naive `Queue` as well as an FS2 stream for handling orders in the background.  The FS2 stream will either save the order (for new orders) or delete the order (for cancels).

The processing follows:
1. On Placing an order, the order is sent to the queue for processing to save it
2. On Cancelling an order, the order is sent to the queue for processing to delete it

The processing is purposefully simple and rather unnecessary, if only to illustrate FS2.

- `OrderProcessor` - this is the main FS2 flow that polls for messages on the queue every few seconds, pipes them through a handler, and then pipes them through to delete the message off of the queue.  We do not explicitly handle errors right now as I planned on implementing this for SQS which does a retry after timeout.  I think this example is good enough, open to other things to show off
- `OrderQueueAlgebra` - this is a queue abstraction generalized to any implementation that follows the SQS approach to receive/delete messages.
- `OrderService` - this was modified to use the queue instead of processing directly
- `OrderQueueInMemoryInterpreter` - a naive implementation of a message queue using purely in-memory constructs.
- `OrderQueueEndpoints` - slight adjustment due to changing the signature of `delete` and renaming to `cancel`