### PR TITLE
Add jdk8 at ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: scala
 dist: xenial
+
+jdk:
+  - openjdk8
+  - openjdk11
+
 scala:
    - 2.12.9
    - 2.13.0
@@ -11,6 +16,10 @@ script:
   - sbt scalafmtSbtCheck scalafmtCheckAll
   - sbt ++$TRAVIS_SCALA_VERSION test
   - ./build.sh
+
+matrix:
+  allow_failures:
+    - jdk: openjdk8
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -106,15 +106,17 @@ In this application, we use **cats effect IO** as our effect type, and use **cat
 
 ## Getting Started
 
+Be aware that this project targets **Java 11**.
+
 Start up sbt:
 
-```
-> sbt
+```bash
+sbt --java-home {your.java.11.location}
 ```
 
 Once sbt has loaded, you can start up the application
 
-```
+```sbtshell
 > ~reStart
 ```
 
@@ -123,7 +125,7 @@ will be automatically rebuilt when you make code changes
 
 To stop the app in sbt, hit the `Enter` key and then type:
 
-```
+```sbtshell
 > reStop
 ```
 


### PR DESCRIPTION
* Run unit tests with OpenJDK 8, but we allow it to fail
* Emphasize that project is used Java 11 as default

Here is the picture at Travis CI:
![Screen Shot 2019-11-19 at 12 12 00](https://user-images.githubusercontent.com/5125598/69116763-73c13400-0ac8-11ea-90dd-190640ccfef7.png)

I guess it will not affect mergify.