### PR TITLE
Fix logging by using slf4j-api version 1.7.30

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ val H2Version = "1.4.200"
 val Http4sVersion = "0.21.7"
 val KindProjectorVersion = "0.11.0"
 val LogbackVersion = "1.2.3"
+val Slf4jVersion = "1.7.30"
 val ScalaCheckVersion = "1.14.3"
 val ScalaTestVersion = "3.2.1"
 val ScalaTestPlusVersion = "3.2.1.0"
@@ -52,6 +53,8 @@ libraryDependencies ++= Seq(
   "io.github.jmcardon" %% "tsec-jwt-sig" % TsecVersion,
   "io.github.jmcardon" %% "tsec-http4s" % TsecVersion,
 )
+
+dependencyOverrides += "org.slf4j" % "slf4j-api" % Slf4jVersion
 
 addCompilerPlugin(
   ("org.typelevel" %% "kind-projector" % KindProjectorVersion).cross(CrossVersion.full),


### PR DESCRIPTION
Logging wasn't working with following message.
`slf4j-api:1.8.0-beta4` was being used as a dependency from `scala-meta:mdoc:2.1.1`. `slf4j-api` 1.8.0+ doesn't support logback 1.2.3 in java 9+

```
scala-pet-store[ERROR] SLF4J: No SLF4J providers were found.
scala-pet-store[ERROR] SLF4J: Defaulting to no-operation (NOP) logger implementation
scala-pet-store[ERROR] SLF4J: See http://www.slf4j.org/codes.html#noProviders for further details.
scala-pet-store[ERROR] SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions prior to 1.8.
scala-pet-store[ERROR] SLF4J: Ignoring binding found at [jar:file:/Users/kapil/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
scala-pet-store[ERROR] SLF4J: See http://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```