### PR TITLE
improvements

### DIFF
--- a/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/config/DatabaseConfig.scala
@@ -36,5 +36,5 @@ object DatabaseConfig {
           .dataSource(cfg.url, cfg.user, cfg.password)
           .load()
       fw.migrate()
-    }.as(())
+    }.void
 }

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/authentication/LoginRequest.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/authentication/LoginRequest.scala
@@ -23,7 +23,7 @@ final case class SignupRequest(
     firstName,
     lastName,
     email,
-    hashedPassword.toString,
+    hashedPassword,
     phone,
     role = role,
   )

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/orders/OrderService.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/orders/OrderService.scala
@@ -13,7 +13,7 @@ class OrderService[F[_]](orderRepo: OrderRepositoryAlgebra[F]) {
     EitherT.fromOptionF(orderRepo.get(id), OrderNotFoundError)
 
   def delete(id: Long)(implicit F: Functor[F]): F[Unit] =
-    orderRepo.delete(id).as(())
+    orderRepo.delete(id).void
 }
 
 object OrderService {

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetService.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetService.scala
@@ -20,7 +20,7 @@ class PetService[F[_]](
   def create(pet: Pet)(implicit M: Monad[F]): F[Either[PetAlreadyExistsError, Pet]] =
     for {
       _     <- validation.doesNotExist(pet)
-      saved <- repository.create(pet).map(Right.apply)
+      saved <- repository.create(pet).map(_.asRight)
     } yield saved
 
   /* Could argue that we could make this idempotent on put and not check if the pet exists */
@@ -35,7 +35,7 @@ class PetService[F[_]](
 
   /* In some circumstances we may care if we actually delete the pet; here we are idempotent and do not care */
   def delete(id: Long)(implicit F: Functor[F]): F[Unit] =
-    repository.delete(id).as(())
+    repository.delete(id).void
 
   def list(pageSize: Int, offset: Int): F[List[Pet]] =
     repository.list(pageSize, offset)

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationAlgebra.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationAlgebra.scala
@@ -1,12 +1,10 @@
 package io.github.pauljamescleary.petstore.domain
 package pets
 
-import cats.data.EitherT
-
 trait PetValidationAlgebra[F[_]] {
   /* Fails with a PetAlreadyExistsError */
-  def doesNotExist(pet: Pet): EitherT[F, PetAlreadyExistsError, Unit]
+  def doesNotExist(pet: Pet): F[Either[PetAlreadyExistsError, Unit]]
 
   /* Fails with a PetNotFoundError if the pet id does not exist or if it is none */
-  def exists(petId: Option[Long]): EitherT[F, PetNotFoundError.type, Unit]
+  def exists(petId: Option[Long]): F[Either[PetNotFoundError.type, Unit]]
 }

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationInterpreter.scala
@@ -11,9 +11,7 @@ class PetValidationInterpreter[F[_]: Applicative](repository: PetRepositoryAlgeb
 
   override def doesNotExist(pet: Pet): F[Either[PetAlreadyExistsError, Unit]] =
     repository.findByNameAndCategory(pet.name, pet.category).map { pets =>
-      val petBios = pets.map(_.bio)
-
-      Either.cond(!petNames.contains(pet.bio), (), PetAlreadyExistsError(pet))
+      Either.cond(!pets.map(_.bio).contains(pet.bio), (), PetAlreadyExistsError(pet))
     }
 
   override def exists(petId: Option[Long]): F[Either[PetNotFoundError.type, Unit]] = {

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationInterpreter.scala
@@ -11,9 +11,9 @@ class PetValidationInterpreter[F[_]: Applicative](repository: PetRepositoryAlgeb
 
   override def doesNotExist(pet: Pet): F[Either[PetAlreadyExistsError, Unit]] =
     repository.findByNameAndCategory(pet.name, pet.category).map { pets =>
-      val petNames = pets.map(_.bio)
+      val petBios = pets.map(_.bio)
 
-      Either.cond(!petNames.contains(pet.name), (), PetAlreadyExistsError(pet))
+      Either.cond(!petNames.contains(pet.bio), (), PetAlreadyExistsError(pet))
     }
 
   override def exists(petId: Option[Long]): F[Either[PetNotFoundError.type, Unit]] = {

--- a/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationInterpreter.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/domain/pets/PetValidationInterpreter.scala
@@ -2,35 +2,27 @@ package io.github.pauljamescleary.petstore.domain
 package pets
 
 import cats.Applicative
-import cats.data.EitherT
-import cats.syntax.all._
+import cats.syntax.functor._
+import cats.syntax.either._
+import cats.syntax.applicative._
 
 class PetValidationInterpreter[F[_]: Applicative](repository: PetRepositoryAlgebra[F])
     extends PetValidationAlgebra[F] {
-  def doesNotExist(pet: Pet): EitherT[F, PetAlreadyExistsError, Unit] = EitherT {
-    repository.findByNameAndCategory(pet.name, pet.category).map { matches =>
-      if (matches.forall(possibleMatch => possibleMatch.bio != pet.bio)) {
-        Right(())
-      } else {
-        Left(PetAlreadyExistsError(pet))
+
+  override def doesNotExist(pet: Pet): F[Either[PetAlreadyExistsError, Unit]] =
+    repository.findByNameAndCategory(pet.name, pet.category).map { pets =>
+      val petNames = pets.map(_.bio)
+
+      Either.cond(!petNames.contains(pet.name), (), PetAlreadyExistsError(pet))
+    }
+
+  override def exists(petId: Option[Long]): F[Either[PetNotFoundError.type, Unit]] = {
+    petId.fold(PetNotFoundError.asLeft[Unit].pure[F]) { id =>
+      repository.get(id).map { maybePet =>
+        Either.cond(maybePet.isDefined, (), PetNotFoundError)
       }
     }
   }
-
-  def exists(petId: Option[Long]): EitherT[F, PetNotFoundError.type, Unit] =
-    EitherT {
-      petId match {
-        case Some(id) =>
-          // Ensure is a little tough to follow, it says "make sure this condition is true, otherwise throw the error specified
-          // In this example, we make sure that the option returned has a value, otherwise the pet was not found
-          repository.get(id).map {
-            case Some(_) => Right(())
-            case _ => Left(PetNotFoundError)
-          }
-        case _ =>
-          Either.left[PetNotFoundError.type, Unit](PetNotFoundError).pure[F]
-      }
-    }
 }
 
 object PetValidationInterpreter {

--- a/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpoints.scala
+++ b/src/main/scala/io/github/pauljamescleary/petstore/infrastructure/endpoint/PetEndpoints.scala
@@ -37,7 +37,7 @@ class PetEndpoints[F[_]: Sync, Auth: JWTMacAlgo] extends Http4sDsl[F] {
     case req @ POST -> Root asAuthed _ =>
       val action = for {
         pet <- req.request.as[Pet]
-        result <- petService.create(pet).value
+        result <- petService.create(pet)
       } yield result
 
       action.flatMap {
@@ -52,7 +52,7 @@ class PetEndpoints[F[_]: Sync, Auth: JWTMacAlgo] extends Http4sDsl[F] {
     case req @ PUT -> Root / LongVar(_) asAuthed _ =>
       val action = for {
         pet <- req.request.as[Pet]
-        result <- petService.update(pet).value
+        result <- petService.update(pet)
       } yield result
 
       action.flatMap {


### PR DESCRIPTION
Monad transformer return type in algebra definition is an anti-pattern, the preferred way is to use `F[Either[_, _]]`, `F[Option[_]]` and so on.

in this PR I refactored `PetValidationAlgebra.scala` and the related code along with a few stylistic improvements.